### PR TITLE
Fix underlines of links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,7 +17,8 @@ body {
 }
 
 a {
-  text-underline: none;
+  text-decoration: none;
+  border-bottom: thin solid #FFF;
   color: #FFFFFF;
 }
 


### PR DESCRIPTION
The default underlines of links uses `text-decoration: underline;` which
is not optimal in typography.